### PR TITLE
cleanup; fix downloading problems; update to 0.2.6

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
+--require spec_helper
 --color

--- a/exe/solrtask
+++ b/exe/solrtask
@@ -2,22 +2,19 @@
 
 $LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 
-puts $LOAD_PATH
-
-
 require 'fileutils'
 require 'optparse'
 require 'solrtasks'
 require 'pathname'
-
 
 options = {
   cache_dir: File.expand_path('.solrtask', '~'),
   local: true,
   uri_base: 'http://localhost:8983/solr',
   install_base: File.expand_path('solr-dir'),
-  default_version: '6.6.0',
-  libfiles: []
+  default_version: '8.2.0',
+  libfiles: [],
+  debug: false
 }
 
 version_set = false
@@ -28,10 +25,10 @@ def_install = Pathname.new(options[:install_base]).relative_path_from(current_pa
 def_solr = Pathname.new(options[:install_base]).join("solr-#{options[:version]}").relative_path_from(current_path)
 
 
-_tasks = %w[status start stop install collections cores schema fieldsi create-collection harmonize-schema repack]
+_tasks = %w[download status start stop install collections cores schema fields create-collection harmonize-schema repack]
 
 hopts = OptionParser.new do |opts|
-  opts.banner = 'Usage: solrtask [options] task [core/collection]'
+  opts.banner = 'Usage: solrtask [options] [task] [core/collection]'
   opts.banner << "\ntask is one of:\n\t#{_tasks.join('|')}"
   opts.banner << "\n\nThe final argument is required for the 'schema' and 'fields' tasks.\n\nOptions: \n\n"
 
@@ -92,6 +89,10 @@ hopts = OptionParser.new do |opts|
     options[:noop] = true
   end
 
+  opts.on('-d', '--debug', 'Log verbosely', default: false) do
+    options[:debug] = true
+  end
+
   opts.on('-h', '--help', 'Print help for this command') do
     puts opts
     exit 0
@@ -105,6 +106,8 @@ command = ARGV.shift || 'status'
 if %w[schema fields create-collection harmonize-schema].include? command
   (cname = ARGV.shift) || raise("[core/collection name] is required for the '#{command}'' command")
 end
+
+SolrTasks.logger.level = :debug if options[:debug]
 
 # functions for querying and persisting current Solr version number
 
@@ -179,8 +182,15 @@ def status(server)
   end
 end
 
+def download(server, options)
+  return unless options[:local]
+
+  SolrTasks::Fetcher.new('.', server.version).download
+end
+
 def install(server, options)
   return unless options[:local]
+
   if !installed?(server)
     puts "\tSolr not found in #{server.install_dir}."
     if !(options[:noop])
@@ -210,18 +220,20 @@ def if_running(server)
 end
 
 case command
+when 'download'
+  puts("Fetching Solr #{server.version} from Apache")
+  download(server, options) ? 0 : 1
 when 'install'
   install(server, options)
 when 'status'
   msg, es = status(server)
-  puts msg
+  puts(msg)
   exit es
 when 'start'
   raise "You must 'install 'the server first" unless installed?(server)
   start(server)
 when 'stop'
   stop(server)
-
 when 'create-collection'
   puts if_running(server) { server.create_collection(cname) }
 when 'collections'
@@ -237,18 +249,18 @@ when 'fields'
   puts if_running(server) { server.get_fields(cname) }
 when 'repack'
   if options[:libfiles].empty?
-    puts 'Did not find any files matching -L or --libs parameter'
+    warn('Did not find any files matching -L or --libs parameter')
     exit 1
   end
 
   f = SolrTasks::Fetcher.new(server.install_dir, server.version)
   unless File.exist?(f.target) 
-    puts "Fetching Solr #{server.version} from Apache"
+    puts("Fetching Solr #{server.version} from Apache")
     f.install(false)
   end
   puts "Adding files to Solr distribution at server/solr/lib"
   options[:libfiles].each { |f|
-    puts "\t#{File.basename(f)}"
+    puts("\t#{File.basename(f)}")
   }
   dest = SolrTasks::Repacker.add_libraries(
     f.target,
@@ -257,8 +269,7 @@ when 'repack'
   )
   puts "Enhanced Solr distribution created in #{dest}"
 else
-
-  puts hopts
-  puts "\n\nUnknown task '#{command}'"
+  warn(hopts)
+  warn("\n\n\tunknown task '#{command}'")
   exit 2
 end

--- a/lib/solrtasks.rb
+++ b/lib/solrtasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'logger'
 require 'yaml'
 require 'net/http'
@@ -34,5 +36,5 @@ module SolrTasks
     attr_accessor :logger
   end
 
-  self.logger = Logger.new(STDOUT)
+  self.logger = Logger.new(STDERR, level: :info)
 end

--- a/lib/solrtasks/extractor.rb
+++ b/lib/solrtasks/extractor.rb
@@ -21,32 +21,37 @@ module SolrTasks
     # This will overwrite any files already in the destination!
     def extract
       dest = nil
-      SolrTasks.logger.info "Extracting #{@source} to #{@dest}"
-      Gem::Package::TarReader.new(Zlib::GzipReader.open(@source)) do |tar|
-        tar.each do |entry|
-          if entry.full_name == TAR_LONGLINK
-            dest = File.join(@dest, entry.read.strip)
-            next
-          end
-          dest ||= File.join(@dest, entry.full_name)
-
-          if entry.directory?
-            FileUtils.rm_rf dest unless File.directory? dest
-            FileUtils.mkdir_p dest, mode: entry.header.mode, verbose: false
-          elsif entry.file?
-            FileUtils.rm_rf dest unless File.file? dest
-            dirname = File.dirname dest
-            FileUtils.mkdir_p dirname unless File.directory? dirname
-            File.open dest, 'wb' do |f|
-              f.print entry.read
+      SolrTasks.logger.debug("Extracting #{@source} to #{@dest}")
+      begin
+        Gem::Package::TarReader.new(Zlib::GzipReader.open(@source)) do |tar|
+          tar.each do |entry|
+            if entry.full_name == TAR_LONGLINK
+              dest = File.join(@dest, entry.read.strip)
+              next
             end
-            FileUtils.chmod entry.header.mode, dest, verbose: false
-          elsif entry.header.typeflag == '2'
-            File.symlink entry.header.linkname, dest
-          end
-          dest = nil
-        end # tar.entry
-      end # tar.read
+            dest ||= File.join(@dest, entry.full_name)
+
+            if entry.directory?
+              FileUtils.rm_rf dest unless File.directory? dest
+              FileUtils.mkdir_p dest, mode: entry.header.mode, verbose: false
+            elsif entry.file?
+              FileUtils.rm_rf dest unless File.file? dest
+              dirname = File.dirname dest
+              FileUtils.mkdir_p dirname unless File.directory? dirname
+              File.open dest, 'wb' do |f|
+                f.print entry.read
+              end
+              FileUtils.chmod entry.header.mode, dest, verbose: false
+            elsif entry.header.typeflag == '2'
+              File.symlink entry.header.linkname, dest
+            end
+            dest = nil
+          end # tar.entry
+        end # tar.read
+      rescue StandardError
+        SolrTasks.logger.warn("Unable to extract Solr source via native ruby; falling back to native tar")
+        `/usr/bin/env tar xzf #{@source} -C #{@dest}`
+      end
     end # method
   end
 end

--- a/lib/solrtasks/version.rb
+++ b/lib/solrtasks/version.rb
@@ -1,3 +1,3 @@
 module SolrTasks
-  VERSION = '0.2.5'.freeze
+  VERSION = '0.2.6'.freeze
 end

--- a/spec/solrtasks/fetcher_spec.rb
+++ b/spec/solrtasks/fetcher_spec.rb
@@ -1,0 +1,17 @@
+describe SolrTasks::Fetcher do
+  let(:modern) { described_class.new('.', '8.2.0') }
+
+  let(:archive) { described_class.new('.', '7.7.1') }
+
+
+  context '#fetch_download_uri' do 
+    it 'finds a modern version on a primary server' do
+      expect(modern.send(:fetch_download_uri).to_s).not_to include('archive')
+    end
+
+	it 'finds an older version on an archive server' do
+      expect(archive.send(:fetch_download_uri).host).to eq('archive.apache.org')
+    end
+  end
+end
+


### PR DESCRIPTION
Fix bug in sha-512 / sha-1 fallback
Adds `download` command (download + verify, no install)
Clean up bugs in finding older versions